### PR TITLE
Allow custom visual styles for NetworkReaders.

### DIFF
--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
@@ -100,7 +100,6 @@ class GenerateNetworkViewsTask extends AbstractTask implements ObservableTask {
 				    // impossible.
                       		    vmm.setVisualStyle(style, view);
                 		}
-				vmm.setVisualStyle(style, view);
 				style.apply(view);
 				
 				if (!view.isSet(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION)

--- a/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
+++ b/core-task-impl/src/main/java/org/cytoscape/task/internal/loadnetwork/GenerateNetworkViewsTask.java
@@ -94,6 +94,12 @@ class GenerateNetworkViewsTask extends AbstractTask implements ObservableTask {
 			if (numGraphObjects < viewThreshold) {
 				final CyNetworkView view = viewReader.buildCyNetworkView(network);
 				networkViewManager.addNetworkView(view);
+				if ("default").equals(vmm.getVisualStyle(view).getTitle()){
+				    // Only set current style when no style, i.e. default, is set for view.
+				    // This allows the viewReader to set custom styles, which is currently
+				    // impossible.
+                      		    vmm.setVisualStyle(style, view);
+                		}
 				vmm.setVisualStyle(style, view);
 				style.apply(view);
 				


### PR DESCRIPTION
Checks if the views generated with buildNetworkView have a style set. If there is such a style do not force the current style.
This is not tested or checked. This skeches only the idea. Please someone integrate the pull request and check this.
